### PR TITLE
refactor: move to hypera.dev

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-ko_fi: sllcoding

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright © 2022 CrystalGames, SLLCoding <luisjk266@gmail.com>
+Copyright (c) 2022 SLLCoding <luisjk266@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the “Software”), to deal

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ schematic.write(new FileOutputStream("schematics/my_schematic.schematic"), regio
 ### Repository
 ```xml
 <repository>
-    <id>crystalgames</id>
-    <url>https://repo.crystalgames.net/snapshots/</url>
+    <id>hypera-snapshots</id>
+    <url>https://repo.hypera.dev/snapshots/</url>
 </repository>
 ```
 ### Dependency
 ```xml
 <dependency>
-    <groupId>net.crystalgames</groupId>
+    <groupId>dev.hypera</groupId>
     <artifactId>Scaffolding</artifactId>
     <version>0.1.1-SNAPSHOT</version>
 </dependency>

--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ schematic.write(new FileOutputStream("schematics/my_schematic.schematic"), regio
 
 ## Build Tools
 
-/!\ Repository is currently down, cloning the repository will be required until fixed.
-
 ### Repository
 ```xml
 <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Scaffolding - Schematic library for Minestom
+  ~  Copyright (c) 2022 SLLCoding <luisjk266@gmail.com>
+  ~
+  ~  Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~  of this software and associated documentation files (the “Software”), to deal
+  ~  in the Software without restriction, including without limitation the rights
+  ~  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~  copies of the Software, and to permit persons to whom the Software is
+  ~  furnished to do so, subject to the following conditions:
+  ~
+  ~  The above copyright notice and this permission notice shall be included in
+  ~  all copies or substantial portions of the Software.
+  ~
+  ~  THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~  THE SOFTWARE.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>net.crystalgames</groupId>
+    <groupId>dev.hypera</groupId>
     <artifactId>Scaffolding</artifactId>
     <version>0.1.3-SNAPSHOT</version>
 
@@ -37,12 +37,12 @@
 
     <distributionManagement>
         <repository>
-            <id>crystalgames</id>
-            <url>https://repo.crystalgames.net/releases/</url>
+            <id>hypera-releases</id>
+            <url>https://repo.hypera.dev/releases/</url>
         </repository>
         <snapshotRepository>
-            <id>crystalgames</id>
-            <url>https://repo.crystalgames.net/snapshots/</url>
+            <id>hypera-snapshots</id>
+            <url>https://repo.hypera.dev/snapshots/</url>
         </snapshotRepository>
     </distributionManagement>
 

--- a/src/main/java/dev/hypera/scaffolding/Scaffolding.java
+++ b/src/main/java/dev/hypera/scaffolding/Scaffolding.java
@@ -1,3 +1,25 @@
+/*
+ * Scaffolding - Schematic library for Minestom
+ *  Copyright (c) 2022 SLLCoding <luisjk266@gmail.com>
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the “Software”), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
 package dev.hypera.scaffolding;
 
 import java.nio.file.Files;

--- a/src/main/java/dev/hypera/scaffolding/Scaffolding.java
+++ b/src/main/java/dev/hypera/scaffolding/Scaffolding.java
@@ -1,9 +1,11 @@
-package net.crystalgames.scaffolding;
+package dev.hypera.scaffolding;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import kotlin.Pair;
-import net.crystalgames.scaffolding.schematic.Schematic;
-import net.crystalgames.scaffolding.schematic.impl.MCEditSchematic;
-import net.crystalgames.scaffolding.schematic.impl.SpongeSchematic;
+import dev.hypera.scaffolding.schematic.Schematic;
+import dev.hypera.scaffolding.schematic.impl.MCEditSchematic;
+import dev.hypera.scaffolding.schematic.impl.SpongeSchematic;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jglrxavpok.hephaistos.nbt.*;
@@ -30,6 +32,18 @@ public class Scaffolding {
 
         if (schematic != null) schematic.read(nbtTag);
         return schematic;
+    }
+
+    /**
+     * Automatically detects the type of schematic and parses the file
+     * @param path Schematic path
+     * @return parsed schematic
+     * @throws IOException if the file is invalid
+     * @throws NBTException if the schematic is invalid
+     */
+    public static @Nullable Schematic fromPath(@NotNull Path path) throws IOException, NBTException {
+        if (!Files.exists(path)) throw new FileNotFoundException("Invalid Schematic: File does not exist");
+        return fromStream(Files.newInputStream(path));
     }
 
     /**

--- a/src/main/java/dev/hypera/scaffolding/instance/SchematicChunkLoader.java
+++ b/src/main/java/dev/hypera/scaffolding/instance/SchematicChunkLoader.java
@@ -1,8 +1,7 @@
-package net.crystalgames.scaffolding.instance;
+package dev.hypera.scaffolding.instance;
 
+import dev.hypera.scaffolding.schematic.Schematic;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
-import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
-import net.crystalgames.scaffolding.schematic.Schematic;
 import net.minestom.server.instance.Chunk;
 import net.minestom.server.instance.DynamicChunk;
 import net.minestom.server.instance.IChunkLoader;
@@ -93,8 +92,7 @@ public class SchematicChunkLoader implements IChunkLoader {
         private int yOffset;
         private int zOffset;
 
-        private Builder() {
-        }
+        private Builder() {}
 
         /**
          * Adds a schematic to this chunk loader.
@@ -138,5 +136,7 @@ public class SchematicChunkLoader implements IChunkLoader {
         public @NotNull SchematicChunkLoader build() {
             return new SchematicChunkLoader(handler, List.copyOf(schematics), xOffset, yOffset, zOffset);
         }
+
     }
+
 }

--- a/src/main/java/dev/hypera/scaffolding/instance/SchematicChunkLoader.java
+++ b/src/main/java/dev/hypera/scaffolding/instance/SchematicChunkLoader.java
@@ -1,3 +1,25 @@
+/*
+ * Scaffolding - Schematic library for Minestom
+ *  Copyright (c) 2022 SLLCoding <luisjk266@gmail.com>
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the “Software”), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
 package dev.hypera.scaffolding.instance;
 
 import dev.hypera.scaffolding.schematic.Schematic;

--- a/src/main/java/dev/hypera/scaffolding/region/Region.java
+++ b/src/main/java/dev/hypera/scaffolding/region/Region.java
@@ -1,10 +1,11 @@
-package net.crystalgames.scaffolding.region;
+package dev.hypera.scaffolding.region;
 
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.instance.Instance;
+import org.jetbrains.annotations.NotNull;
 
-public record Region(Instance instance, Point lower, Point upper) {
+public record Region(@NotNull Instance instance, @NotNull Point lower, @NotNull Point upper) {
 
     public int sizeX() {
         return (upper.blockX() - lower.blockX()) + 1;

--- a/src/main/java/dev/hypera/scaffolding/region/Region.java
+++ b/src/main/java/dev/hypera/scaffolding/region/Region.java
@@ -1,3 +1,25 @@
+/*
+ * Scaffolding - Schematic library for Minestom
+ *  Copyright (c) 2022 SLLCoding <luisjk266@gmail.com>
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the “Software”), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
 package dev.hypera.scaffolding.region;
 
 import net.minestom.server.coordinate.Point;

--- a/src/main/java/dev/hypera/scaffolding/schematic/Schematic.java
+++ b/src/main/java/dev/hypera/scaffolding/schematic/Schematic.java
@@ -1,3 +1,25 @@
+/*
+ * Scaffolding - Schematic library for Minestom
+ *  Copyright (c) 2022 SLLCoding <luisjk266@gmail.com>
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the “Software”), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
 package dev.hypera.scaffolding.schematic;
 
 import dev.hypera.scaffolding.region.Region;

--- a/src/main/java/dev/hypera/scaffolding/schematic/Schematic.java
+++ b/src/main/java/dev/hypera/scaffolding/schematic/Schematic.java
@@ -1,8 +1,7 @@
-package net.crystalgames.scaffolding.schematic;
+package dev.hypera.scaffolding.schematic;
 
-import net.crystalgames.scaffolding.region.Region;
+import dev.hypera.scaffolding.region.Region;
 import net.minestom.server.coordinate.Point;
-import net.minestom.server.coordinate.Pos;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.block.Block;
 import org.jetbrains.annotations.NotNull;
@@ -42,4 +41,5 @@ public interface Schematic {
      * @param setter the block setter
      */
     void apply(@NotNull Block.Setter setter);
+
 }

--- a/src/main/java/dev/hypera/scaffolding/schematic/impl/MCEditSchematic.java
+++ b/src/main/java/dev/hypera/scaffolding/schematic/impl/MCEditSchematic.java
@@ -1,7 +1,7 @@
-package net.crystalgames.scaffolding.schematic.impl;
+package dev.hypera.scaffolding.schematic.impl;
 
-import net.crystalgames.scaffolding.region.Region;
-import net.crystalgames.scaffolding.schematic.Schematic;
+import dev.hypera.scaffolding.schematic.Schematic;
+import dev.hypera.scaffolding.region.Region;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.instance.Instance;
@@ -182,4 +182,5 @@ public class MCEditSchematic implements Schematic {
             }
         }
     }
+
 }

--- a/src/main/java/dev/hypera/scaffolding/schematic/impl/MCEditSchematic.java
+++ b/src/main/java/dev/hypera/scaffolding/schematic/impl/MCEditSchematic.java
@@ -1,3 +1,25 @@
+/*
+ * Scaffolding - Schematic library for Minestom
+ *  Copyright (c) 2022 SLLCoding <luisjk266@gmail.com>
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the “Software”), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
 package dev.hypera.scaffolding.schematic.impl;
 
 import dev.hypera.scaffolding.schematic.Schematic;

--- a/src/main/java/dev/hypera/scaffolding/schematic/impl/SpongeSchematic.java
+++ b/src/main/java/dev/hypera/scaffolding/schematic/impl/SpongeSchematic.java
@@ -1,7 +1,7 @@
-package net.crystalgames.scaffolding.schematic.impl;
+package dev.hypera.scaffolding.schematic.impl;
 
-import net.crystalgames.scaffolding.region.Region;
-import net.crystalgames.scaffolding.schematic.Schematic;
+import dev.hypera.scaffolding.schematic.Schematic;
+import dev.hypera.scaffolding.region.Region;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.instance.Instance;
@@ -218,7 +218,7 @@ public class SpongeSchematic implements Schematic {
     }
 
     @Override
-    public void apply(Block.@NotNull Setter setter) {
+    public void apply(@NotNull Block.Setter setter) {
         for (Region.Block block : regionBlocks) {
             Pos pos = block.position();
             Block minestomBlock = Block.fromStateId(block.stateId());

--- a/src/main/java/dev/hypera/scaffolding/schematic/impl/SpongeSchematic.java
+++ b/src/main/java/dev/hypera/scaffolding/schematic/impl/SpongeSchematic.java
@@ -1,3 +1,25 @@
+/*
+ * Scaffolding - Schematic library for Minestom
+ *  Copyright (c) 2022 SLLCoding <luisjk266@gmail.com>
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the “Software”), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
 package dev.hypera.scaffolding.schematic.impl;
 
 import dev.hypera.scaffolding.schematic.Schematic;

--- a/src/test/java/dev/hypera/scaffolding/test/Server.java
+++ b/src/test/java/dev/hypera/scaffolding/test/Server.java
@@ -20,10 +20,10 @@
  *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  *  THE SOFTWARE.
  */
-package dev.sllcoding.scaffolding.test;
+package dev.hypera.scaffolding.test;
 
-import dev.sllcoding.scaffolding.test.commands.TestCommand;
-import dev.sllcoding.scaffolding.test.generator.Generator;
+import dev.hypera.scaffolding.test.commands.TestCommand;
+import dev.hypera.scaffolding.test.generator.Generator;
 import java.nio.file.Path;
 import dev.hypera.scaffolding.Scaffolding;
 import dev.hypera.scaffolding.instance.SchematicChunkLoader;

--- a/src/test/java/dev/hypera/scaffolding/test/commands/TestCommand.java
+++ b/src/test/java/dev/hypera/scaffolding/test/commands/TestCommand.java
@@ -20,30 +20,34 @@
  *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  *  THE SOFTWARE.
  */
-package dev.sllcoding.scaffolding.test.generator;
+package dev.hypera.scaffolding.test.commands;
 
-import net.minestom.server.instance.ChunkGenerator;
-import net.minestom.server.instance.ChunkPopulator;
-import net.minestom.server.instance.batch.ChunkBatch;
-import net.minestom.server.instance.block.Block;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import java.nio.file.Path;
+import dev.hypera.scaffolding.Scaffolding;
+import dev.hypera.scaffolding.schematic.Schematic;
+import net.minestom.server.command.builder.Command;
+import net.minestom.server.coordinate.Pos;
+import net.minestom.server.entity.Player;
+import net.minestom.server.instance.Instance;
 
-import java.util.List;
+public class TestCommand extends Command {
 
-public class Generator implements ChunkGenerator {
+    public TestCommand() {
+        super("test");
 
-    @Override
-    public void generateChunkData(@NotNull ChunkBatch chunkBatch, int chunkX, int chunkZ) {
-        for (int x = 0; x < 16; x++)
-            for (int z = 0; z < 16; z++)
-                for (int y = 0; y < 40; y++)
-                    chunkBatch.setBlock(x, y, z, Block.STONE);
-    }
+        setDefaultExecutor((sender, context) -> {
+            try {
+                Schematic schematic = Scaffolding.fromPath(Path.of("schematic.schematic"));
 
-    @Override
-    public @Nullable List<ChunkPopulator> getPopulators() {
-        return null;
+                Player player = (Player) sender;
+                Instance instance = player.getInstance();
+                Pos position = player.getPosition();
+
+                schematic.build(instance, position).thenRun(() -> player.sendMessage("Done!"));
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
     }
 
 }

--- a/src/test/java/dev/hypera/scaffolding/test/generator/Generator.java
+++ b/src/test/java/dev/hypera/scaffolding/test/generator/Generator.java
@@ -20,34 +20,30 @@
  *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  *  THE SOFTWARE.
  */
-package dev.sllcoding.scaffolding.test.commands;
+package dev.hypera.scaffolding.test.generator;
 
-import java.nio.file.Path;
-import dev.hypera.scaffolding.Scaffolding;
-import dev.hypera.scaffolding.schematic.Schematic;
-import net.minestom.server.command.builder.Command;
-import net.minestom.server.coordinate.Pos;
-import net.minestom.server.entity.Player;
-import net.minestom.server.instance.Instance;
+import net.minestom.server.instance.ChunkGenerator;
+import net.minestom.server.instance.ChunkPopulator;
+import net.minestom.server.instance.batch.ChunkBatch;
+import net.minestom.server.instance.block.Block;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-public class TestCommand extends Command {
+import java.util.List;
 
-    public TestCommand() {
-        super("test");
+public class Generator implements ChunkGenerator {
 
-        setDefaultExecutor((sender, context) -> {
-            try {
-                Schematic schematic = Scaffolding.fromPath(Path.of("schematic.schematic"));
+    @Override
+    public void generateChunkData(@NotNull ChunkBatch chunkBatch, int chunkX, int chunkZ) {
+        for (int x = 0; x < 16; x++)
+            for (int z = 0; z < 16; z++)
+                for (int y = 0; y < 40; y++)
+                    chunkBatch.setBlock(x, y, z, Block.STONE);
+    }
 
-                Player player = (Player) sender;
-                Instance instance = player.getInstance();
-                Pos position = player.getPosition();
-
-                schematic.build(instance, position).thenRun(() -> player.sendMessage("Done!"));
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        });
+    @Override
+    public @Nullable List<ChunkPopulator> getPopulators() {
+        return null;
     }
 
 }

--- a/src/test/java/dev/sllcoding/scaffolding/test/Server.java
+++ b/src/test/java/dev/sllcoding/scaffolding/test/Server.java
@@ -1,3 +1,25 @@
+/*
+ * Scaffolding - Schematic library for Minestom
+ *  Copyright (c) 2022 SLLCoding <luisjk266@gmail.com>
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the “Software”), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
 package dev.sllcoding.scaffolding.test;
 
 import dev.sllcoding.scaffolding.test.commands.TestCommand;

--- a/src/test/java/dev/sllcoding/scaffolding/test/Server.java
+++ b/src/test/java/dev/sllcoding/scaffolding/test/Server.java
@@ -2,9 +2,10 @@ package dev.sllcoding.scaffolding.test;
 
 import dev.sllcoding.scaffolding.test.commands.TestCommand;
 import dev.sllcoding.scaffolding.test.generator.Generator;
-import net.crystalgames.scaffolding.Scaffolding;
-import net.crystalgames.scaffolding.instance.SchematicChunkLoader;
-import net.crystalgames.scaffolding.schematic.Schematic;
+import java.nio.file.Path;
+import dev.hypera.scaffolding.Scaffolding;
+import dev.hypera.scaffolding.instance.SchematicChunkLoader;
+import dev.hypera.scaffolding.schematic.Schematic;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.entity.GameMode;
@@ -15,7 +16,6 @@ import net.minestom.server.utils.NamespaceID;
 import net.minestom.server.world.DimensionType;
 import org.jglrxavpok.hephaistos.nbt.NBTException;
 
-import java.io.File;
 import java.io.IOException;
 
 public class Server {
@@ -32,7 +32,7 @@ public class Server {
         instance.setChunkGenerator(new Generator());
         // Load schematic for schematic chunk loader
         try {
-            Schematic schematic = Scaffolding.fromFile(new File("schematic.schematic"));
+            Schematic schematic = Scaffolding.fromPath(Path.of("schematic.schematic"));
             SchematicChunkLoader chunkLoader = SchematicChunkLoader.builder()
                     .addSchematic(schematic)
                     .build();

--- a/src/test/java/dev/sllcoding/scaffolding/test/commands/TestCommand.java
+++ b/src/test/java/dev/sllcoding/scaffolding/test/commands/TestCommand.java
@@ -1,13 +1,12 @@
 package dev.sllcoding.scaffolding.test.commands;
 
-import net.crystalgames.scaffolding.Scaffolding;
-import net.crystalgames.scaffolding.schematic.Schematic;
+import java.nio.file.Path;
+import dev.hypera.scaffolding.Scaffolding;
+import dev.hypera.scaffolding.schematic.Schematic;
 import net.minestom.server.command.builder.Command;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.entity.Player;
 import net.minestom.server.instance.Instance;
-
-import java.io.File;
 
 public class TestCommand extends Command {
 
@@ -16,7 +15,7 @@ public class TestCommand extends Command {
 
         setDefaultExecutor((sender, context) -> {
             try {
-                Schematic schematic = Scaffolding.fromFile(new File("schematic.schematic"));
+                Schematic schematic = Scaffolding.fromPath(Path.of("schematic.schematic"));
 
                 Player player = (Player) sender;
                 Instance instance = player.getInstance();

--- a/src/test/java/dev/sllcoding/scaffolding/test/commands/TestCommand.java
+++ b/src/test/java/dev/sllcoding/scaffolding/test/commands/TestCommand.java
@@ -1,3 +1,25 @@
+/*
+ * Scaffolding - Schematic library for Minestom
+ *  Copyright (c) 2022 SLLCoding <luisjk266@gmail.com>
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the “Software”), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
 package dev.sllcoding.scaffolding.test.commands;
 
 import java.nio.file.Path;

--- a/src/test/java/dev/sllcoding/scaffolding/test/generator/Generator.java
+++ b/src/test/java/dev/sllcoding/scaffolding/test/generator/Generator.java
@@ -1,3 +1,25 @@
+/*
+ * Scaffolding - Schematic library for Minestom
+ *  Copyright (c) 2022 SLLCoding <luisjk266@gmail.com>
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the “Software”), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
 package dev.sllcoding.scaffolding.test.generator;
 
 import net.minestom.server.instance.ChunkGenerator;


### PR DESCRIPTION
CrystalGames is being discontinued and the project has been transferred to Hypera Development.
This pull request moves the project to the domain `hypera.dev` and sets up Hypera's maven repository.